### PR TITLE
Allow user to remove orphaned keys

### DIFF
--- a/cmd_rotate_keys.go
+++ b/cmd_rotate_keys.go
@@ -24,8 +24,11 @@ import (
 // Structure for our options and state.
 type rotateKeysCommand struct {
 
-	// Should we force deletion of old keys?
+	// Should we force deletion of old keys without prompting?
 	Force bool
+
+	// Should we explicitly remove orphaned keys
+	Cleanup bool
 
 	// Configuration path, defaults to ~/.aws/credentials
 	Path string
@@ -34,6 +37,7 @@ type rotateKeysCommand struct {
 // Arguments adds per-command args to the object.
 func (r *rotateKeysCommand) Arguments(f *flag.FlagSet) {
 
+	f.BoolVar(&r.Cleanup, "cleanup", false, "Should we remove orphaned keys, automatically?")
 	f.BoolVar(&r.Force, "force", false, "Should we force removal of old keys without prompting?")
 	f.StringVar(&r.Path, "path", "", "The location of the configuration file to modify?")
 
@@ -165,10 +169,18 @@ func (r *rotateKeysCommand) Execute(args []string) int {
 		return 1
 	}
 
-	// More than one key?
+	// AWS only allows two keys, at the most.
+	//
+	// If there is one key then we just create a new one, meaning
+	// we have hit the limit - and that's OK.
+	//
+	// If there were previously two keys already present then we
+	// have to remove one before we can create the new replacement//
+	//
+	// Look for more than one?
 	if len(keys.AccessKeyMetadata) > 1 {
 
-		// If we're not forcing ..
+		// If we're not forcing..
 		if !r.Force {
 
 			// Then ensure the user confirms removal.
@@ -179,7 +191,7 @@ func (r *rotateKeysCommand) Execute(args []string) int {
 			}
 		}
 
-		// Now remove the older key.
+		// Remove the older key.
 		_, err = iamClient.DeleteAccessKey(&iam.DeleteAccessKeyInput{
 			AccessKeyId: keys.AccessKeyMetadata[0].AccessKeyId,
 		})
@@ -190,6 +202,12 @@ func (r *rotateKeysCommand) Execute(args []string) int {
 			return 1
 		}
 
+		// At this point we've changed:
+		//
+		// There were two keys - the maximum.
+		//
+		// We've now removed one, which means we have room to create
+		// a new one.
 	}
 
 	// Open the existing credentials file
@@ -200,10 +218,10 @@ func (r *rotateKeysCommand) Execute(args []string) int {
 	}
 	defer file.Close()
 
-	// Create a new key now.
+	// Actually create the new key now.
 	created, err := iamClient.CreateAccessKey(&iam.CreateAccessKeyInput{})
 	if err != nil {
-		fmt.Printf("error creating new keys: %s\n", err)
+		fmt.Printf("error creating the new key: %s\n", err)
 		return 1
 	}
 
@@ -213,7 +231,7 @@ func (r *rotateKeysCommand) Execute(args []string) int {
 	for scanner.Scan() {
 		content = append(content, scanner.Text())
 	}
-	if err := scanner.Err(); err != nil {
+	if err = scanner.Err(); err != nil {
 		fmt.Printf("error processing the config file: %s\n", err)
 		return 1
 	}
@@ -235,7 +253,7 @@ func (r *rotateKeysCommand) Execute(args []string) int {
 		if !awsAccessKeyID && strings.HasPrefix(line, "aws_access_key_id") {
 
 			// only update the first one
-			_, err := out.WriteString("aws_access_key_id=" + *created.AccessKey.AccessKeyId + "\n")
+			_, err = out.WriteString("aws_access_key_id=" + *created.AccessKey.AccessKeyId + "\n")
 			if err != nil {
 				fmt.Printf("error writing to file:%s\n", err.Error())
 				return 1
@@ -246,7 +264,7 @@ func (r *rotateKeysCommand) Execute(args []string) int {
 
 		// Update in-place
 		if !awsSecretAccessKeyID && strings.HasPrefix(line, "aws_secret_access_key") {
-			_, err := out.WriteString("aws_secret_access_key=" + *created.AccessKey.SecretAccessKey + "\n")
+			_, err = out.WriteString("aws_secret_access_key=" + *created.AccessKey.SecretAccessKey + "\n")
 			if err != nil {
 				fmt.Printf("error writing to file:%s\n", err.Error())
 				return 1
@@ -257,7 +275,7 @@ func (r *rotateKeysCommand) Execute(args []string) int {
 		}
 
 		// Otherwise copy the old line into place.
-		_, err := out.WriteString(line + "\n")
+		_, err = out.WriteString(line + "\n")
 		if err != nil {
 			fmt.Printf("error writing to file:%s\n", err.Error())
 			return 1
@@ -267,6 +285,39 @@ func (r *rotateKeysCommand) Execute(args []string) int {
 
 	// Close the output file
 	out.Close()
+
+	// At this point we've created a new key, and handled the
+	// update of the users configuration file.
+	//
+	// If we're going to clean any orphaned keys we should do that now.
+	if r.Cleanup {
+
+		// We previous retrieved the keys when we started,
+		// so loop over those.
+		//
+		// Any key that is present there should be removed.
+		for _, key := range(keys.AccessKeyMetadata)		{
+
+			fmt.Printf("Removing orphaned key: %s", *key.AccessKeyId)
+
+			// Delete the key
+			_, err = iamClient.DeleteAccessKey(&iam.DeleteAccessKeyInput{
+				AccessKeyId: key.AccessKeyId,
+			})
+
+			if err != nil {
+				// Failure to delete the key is unfortunate,
+				// but it isn't terminal.
+				//
+				// We have after all already created a new
+				// key and updated the users' config to use it.
+				fmt.Printf(" - failed to remove %s", err.Error())
+			}
+
+			// newline at the end of the output.
+			fmt.Printf("\n")
+		}
+	}
 
 	return 0
 }

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/skx/aws-utils
 go 1.17
 
 require (
-	github.com/aws/aws-sdk-go v1.44.14
+	github.com/aws/aws-sdk-go v1.44.18
 	github.com/pkg/errors v0.9.1
 	github.com/skx/subcommands v0.9.2
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/aws/aws-sdk-go v1.44.14 h1:qd7/muV1rElsbvkK9D1nHUzBoDlEw2etfeo4IE82eSQ=
-github.com/aws/aws-sdk-go v1.44.14/go.mod h1:y4AeaBuwd2Lk+GepC1E9v0qOiTws0MIWAX4oIKwKHZo=
+github.com/aws/aws-sdk-go v1.44.18 h1:rPDxVLNZL9R76yifC0kYOnfnkMswLfy89c8LBJSyvgY=
+github.com/aws/aws-sdk-go v1.44.18/go.mod h1:y4AeaBuwd2Lk+GepC1E9v0qOiTws0MIWAX4oIKwKHZo=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=


### PR DESCRIPTION
This closes #19, by making it possible to remove the orphaned
keys that might remain after generating a new one.

If there are two keys present before things start then one
will be removed as part of the generation of the new one - in that
case we'll see an errors when we try to remove that a second time,
but that is harmless.